### PR TITLE
Wellcome: use relative_path as final location

### DIFF
--- a/storage_service/locations/fixtures/wellcome.json
+++ b/storage_service/locations/fixtures/wellcome.json
@@ -29,7 +29,7 @@
         "uuid": "0af68d1f-456e-49b2-8791-00f46df65e5d",
         "access_protocol": "WELLCOME",
         "staging_path": "/var/archivematica/storage_service/",
-        "path": "/archivematica",
+        "path": "/",
         "size": null
     }
 },
@@ -42,7 +42,7 @@
         "space": "0af68d1f-456e-49b2-8791-00f46df65e5d",
         "enabled": true,
         "quota": null,
-        "relative_path": "aips",
+        "relative_path": "born-digital",
         "purpose": "AS",
         "uuid": "59987281-d8f6-4b46-b854-559981de49e8"
     }

--- a/storage_service/locations/models/wellcome.py
+++ b/storage_service/locations/models/wellcome.py
@@ -81,15 +81,14 @@ class WellcomeStorageService(S3SpaceModelMixin):
         """ Moves self.staging_path/src_path to dest_path. """
         LOGGER.debug('Moving %s to %s on Wellcome storage' % (src_path, dest_path))
 
+        s3_temporary_path = dest_path.lstrip('/')
         bucket = self.s3_resource.Bucket(self.s3_bucket)
 
         if os.path.isfile(src_path):
-            # strip leading slash on dest_path
-            s3_path = dest_path.lstrip('/')
 
             # Upload to s3
             with open(src_path, 'rb') as data:
-                bucket.upload_fileobj(data, s3_path)
+                bucket.upload_fileobj(data, s3_temporary_path)
 
             wellcome = StorageServiceClient(
                 api_url=self.api_root_url,
@@ -108,10 +107,15 @@ class WellcomeStorageService(S3SpaceModelMixin):
                     })
                 ))
 
+            # strip leading slash on dest_path
+            #space_id = os.path.basename(os.path.dirname(dest_path))
+            location = package.current_location
+            space_id = location.relative_path.strip(os.path.sep)
+
             LOGGER.info('Callback will be to %s' % callback_url)
             location = wellcome.create_s3_ingest(
-                space_id='born-digital',
-                s3_key=s3_path,
+                space_id=space_id,
+                s3_key=s3_temporary_path,
                 s3_bucket=self.bucket_name,
                 callback_url=callback_url,
             )

--- a/storage_service/locations/tests/test_wellcome.py
+++ b/storage_service/locations/tests/test_wellcome.py
@@ -30,24 +30,11 @@ class TestWellcomeStorage(TestCase):
 
         self.wellcome_object.move_from_storage_service(
             os.path.join(FIXTURES_DIR, 'small_compressed_bag.zip'),
-            '/ingests/bag.zip',
+            '/born-digital/bag.zip',
             package=package
         )
 
-        assert self._s3.get_object(Bucket='ingest-bucket', Key='ingests/bag.zip')
-
-    @mock.patch('locations.models.wellcome.StorageServiceClient')
-    def test_move_from_ss_uploads_to_s3(self, mock_wellcome_client_class):
-        package = models.Package.objects.get(uuid="6465da4a-ea88-4300-ac56-9641125f1276")
-
-        self.wellcome_object.move_from_storage_service(
-            os.path.join(FIXTURES_DIR, 'small_compressed_bag.zip'),
-            '/ingests/bag.zip',
-            package=package
-        )
-
-        assert self._s3.get_object(Bucket='ingest-bucket', Key='ingests/bag.zip')
-
+        assert self._s3.get_object(Bucket='ingest-bucket', Key='born-digital/bag.zip')
 
     @mock.patch('locations.models.wellcome.StorageServiceClient')
     def test_move_from_ss_wellcome_client_calls(self, mock_wellcome_client_class):
@@ -55,7 +42,7 @@ class TestWellcomeStorage(TestCase):
 
         self.wellcome_object.move_from_storage_service(
             os.path.join(FIXTURES_DIR, 'small_compressed_bag.zip'),
-            '/ingests/bag.zip',
+            '/born-digital/bag.zip',
             package=package
         )
 
@@ -68,7 +55,7 @@ class TestWellcomeStorage(TestCase):
 
         mock_wellcome_client_class.return_value.create_s3_ingest.assert_called_with(
             space_id='born-digital',
-            s3_key='ingests/bag.zip',
+            s3_key='born-digital/bag.zip',
             s3_bucket=self.wellcome_object.s3_bucket,
             callback_url='https://test.localhost/api/v2/file/6465da4a-ea88-4300-ac56-9641125f1276/wellcome_callback/?username=username&api_key=api_key',
         )
@@ -88,7 +75,7 @@ class TestWellcomeStorage(TestCase):
 
         self.wellcome_object.move_from_storage_service(
             os.path.join(FIXTURES_DIR, 'small_compressed_bag.zip'),
-            '/ingests/bag.zip',
+            '/born-digital/bag.zip',
             package=package
         )
 
@@ -119,7 +106,7 @@ class TestWellcomeStorage(TestCase):
 
         self.wellcome_object.move_from_storage_service(
             os.path.join(FIXTURES_DIR, 'small_compressed_bag.zip'),
-            '/ingests/bag.zip',
+            '/born-digital/bag.zip',
             package=package
         )
 
@@ -142,6 +129,6 @@ class TestWellcomeStorage(TestCase):
         with pytest.raises(models.StorageException):
             self.wellcome_object.move_from_storage_service(
                 os.path.join(FIXTURES_DIR, 'small_compressed_bag.zip'),
-                '/ingests/bag.zip',
+                '/born-digital/bag.zip',
                 package=package
             )


### PR DESCRIPTION
Rather than using the relative_path as the temporary s3 upload location, use it as the space id for the storage service. This will enable different storage locations to be used to point at different subdirectories of a bucket.