### PR TITLE
Upgrade wellcome client version

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -22,7 +22,7 @@ python-swiftclient==3.3.0
 requests==2.21.0
 requests-oauthlib==1.2.0
 sword2==0.2.1
-wellcome-storage-service==1.0.0
+wellcome-storage-service==1.1.0
 whitenoise==3.3.0
 agentarchives==0.4.0
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -72,7 +72,10 @@ requests-oauthlib==1.2.0
 requests==2.21.0
 rfc3986==1.3.2            # via oslo.config
 s3transfer==0.2.0         # via boto3
-urllib3==1.24.3           # via requests
-wellcome-storage-service==1.0.0
+six==1.12.0               # via cryptography, debtcollector, django-extensions, keystoneauth1, metsrw, oslo.config, oslo.i18n, oslo.serialization, oslo.utils, pyopenssl, python-dateutil, python-keystoneclient, python-swiftclient, stevedore
+stevedore==1.30.1         # via keystoneauth1, oslo.config, python-keystoneclient
+sword2==0.2.1
+urllib3==1.24.3           # via botocore, requests
+wellcome-storage-service==1.1.0
 whitenoise==3.3.0
 wrapt==1.11.1             # via debtcollector, positional

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -86,6 +86,6 @@ stevedore==1.30.1
 sword2==0.2.1
 transifex-client==0.12.2
 urllib3==1.24.3
-wellcome-storage-service==1.0.0
+wellcome-storage-service==1.1.0
 whitenoise==3.3.0
 wrapt==1.11.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -78,6 +78,6 @@ six==1.12.0
 stevedore==1.30.1
 sword2==0.2.1
 urllib3==1.24.3
-wellcome-storage-service==1.0.0
+wellcome-storage-service==1.1.0
 whitenoise==3.3.0
 wrapt==1.11.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,7 +5,6 @@
 #    pip-compile --output-file=test.txt test.in
 #
 agentarchives==0.4.0
-appnope==0.1.0            # via ipython
 asn1crypto==0.24.0
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
@@ -72,7 +71,7 @@ git+https://github.com/seatme/django-longer-username.git@seatme#egg=longeruserna
 lxml==3.7.3
 markupsafe==1.1.1         # via jinja2
 metsrw==0.3.8
-mock==3.0.5               # via pytest-mock, vcrpy
+mock==3.0.5               # via moto, pytest-mock, responses, vcrpy
 monotonic==1.5
 more-itertools==5.0.0     # via pytest
 moto==1.3.8
@@ -87,7 +86,7 @@ oslo.config==6.9.0
 oslo.i18n==3.23.1
 oslo.serialization==2.29.1
 oslo.utils==3.41.0
-pathlib2==2.3.3           # via ipython, pickleshare, pytest, pytest-django
+pathlib2==2.3.3           # via cfn-lint, ipython, pickleshare, pytest, pytest-django
 pbr==5.2.0
 pexpect==4.7.0            # via ipython
 pickleshare==0.7.5        # via ipython
@@ -118,8 +117,8 @@ pytz==2019.1
 pyyaml==5.1
 requests-oauthlib==1.2.0
 requests==2.21.0
-rfc3986==1.3.2
 responses==0.10.6         # via moto
+rfc3986==1.3.2
 rsa==4.0                  # via python-jose
 s3transfer==0.2.0
 scandir==1.10.0           # via pathlib2
@@ -135,7 +134,7 @@ vcrpy==2.0.1
 virtualenv==16.6.0        # via tox
 wcwidth==0.1.7            # via prompt-toolkit
 websocket-client==0.56.0  # via docker
-wellcome-storage-service==1.0.0
+wellcome-storage-service==1.1.0
 werkzeug==0.15.2          # via moto
 whitenoise==3.3.0
 wrapt==1.11.1

--- a/storage_service/locations/models/wellcome.py
+++ b/storage_service/locations/models/wellcome.py
@@ -107,8 +107,7 @@ class WellcomeStorageService(S3SpaceModelMixin):
                     })
                 ))
 
-            # strip leading slash on dest_path
-            #space_id = os.path.basename(os.path.dirname(dest_path))
+            # Use the relative_path as the storage service space ID
             location = package.current_location
             space_id = location.relative_path.strip(os.path.sep)
 
@@ -118,6 +117,8 @@ class WellcomeStorageService(S3SpaceModelMixin):
                 s3_key=s3_temporary_path,
                 s3_bucket=self.bucket_name,
                 callback_url=callback_url,
+                external_identifier=package.uuid,
+                ingest_type="create",
             )
             LOGGER.info('Ingest_location: %s' % location)
 


### PR DESCRIPTION
Use wellcome client 1.1.0 and send extra external_identifier and ingest_type fields

I think pip-tools has picked up on a couple of unrelated things here, but they appear reasonable.