### PR TITLE
Use external id as location

### DIFF
--- a/storage_service/locations/models/wellcome.py
+++ b/storage_service/locations/models/wellcome.py
@@ -29,13 +29,13 @@ def handle_ingest(ingest, package):
     """
     status = ingest['status']['id']
     if status == 'succeeded':
-        bag_id = ingest['bag']['id']
+        external_id = ingest['bag']['info']['externalIdentifier']
         package.status = Package.UPLOADED
-        package.misc_attributes['bag_id'] = bag_id
         package.misc_attributes['ingest_id'] = ingest['id']
-        package.current_path = bag_id
+        package.current_path = external_id
         package.save()
-        LOGGER.info('Bag ID: %s' % bag_id)
+        LOGGER.info('Ingest ID: %s' % external_id)
+        LOGGER.info('External ID: %s' % external_id)
     elif status =='failed':
         LOGGER.error('Ingest failed')
         package.status = Package.FAIL

--- a/storage_service/locations/tests/test_wellcome.py
+++ b/storage_service/locations/tests/test_wellcome.py
@@ -102,7 +102,9 @@ class TestWellcomeStorage(TestCase):
                 'id': 'succeeded',
             },
             'bag': {
-                'id': 'bag-id',
+                'info': {
+                    'externalIdentifier': 'external-id',
+                }
             },
         }
 
@@ -114,6 +116,8 @@ class TestWellcomeStorage(TestCase):
 
         package.refresh_from_db()
         assert package.status == models.Package.UPLOADED
+        assert package.current_path == 'external-id'
+        assert package.misc_attributes['ingest_id'] == 'ingest-id'
 
     @mock.patch('time.sleep')
     @mock.patch('locations.models.wellcome.StorageServiceClient')

--- a/storage_service/locations/tests/test_wellcome.py
+++ b/storage_service/locations/tests/test_wellcome.py
@@ -58,6 +58,8 @@ class TestWellcomeStorage(TestCase):
             s3_key='born-digital/bag.zip',
             s3_bucket=self.wellcome_object.s3_bucket,
             callback_url='https://test.localhost/api/v2/file/6465da4a-ea88-4300-ac56-9641125f1276/wellcome_callback/?username=username&api_key=api_key',
+            external_identifier=package.uuid,
+            ingest_type='create',
         )
 
     @mock.patch('time.sleep')


### PR DESCRIPTION
Bag ID no longer exists in the json from the Wellcome storage service. Instead of using this for the package path, take the external identifier.

Here I'm also fixing some tests which should have been updated in https://github.com/wellcometrust/archivematica-storage-service/pull/6