### PR TITLE
Support Archivematica reingests

### DIFF
--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -291,6 +291,7 @@ def get_compression(pointer_path):
     :returns: one of the constants in ``COMPRESSION_ALGORITHMS``.
     """
     doc = etree.parse(pointer_path)
+    fallback_algorithm = COMPRESSION_7Z_BZIP
 
     puid = doc.findtext(".//premis:formatRegistryKey", namespaces=NSMAP)
     if puid is None:
@@ -308,21 +309,22 @@ def get_compression(pointer_path):
             return COMPRESSION_7Z_COPY
         else:
             LOGGER.warning(
-                "Unable to determine reingested compression"
-                " algorithm, defaulting to bzip2."
+                "Unable to determine reingested compression algorithm for %s "
+                "(%r, %r), defaulting to %s.",
+                pointer_path, puid, algo, fallback_algorithm
             )
-            return COMPRESSION_7Z_BZIP
+            return fallback_algorithm
     elif puid == PRONOM_BZIP2:  # Bzipped (probably tar)
         return COMPRESSION_TAR_BZIP2
     elif puid == PRONOM_GZIP:
         return COMPRESSION_TAR_GZIP
     else:
         LOGGER.warning(
-            "Unable to determine reingested file format %s,"
-            " defaulting recompression algorithm to bzip2.",
-            puid
+            "Unable to determine reingested file format for %s (%r),"
+            " defaulting recompression algorithm to %s.",
+            pointer_path, puid, fallback_algorithm
         )
-        return COMPRESSION_7Z_BZIP
+        return fallback_algorithm
 
 
 def get_compress_command(compression, extract_path, basename, full_path):

--- a/storage_service/common/utils.py
+++ b/storage_service/common/utils.py
@@ -318,8 +318,9 @@ def get_compression(pointer_path):
         return COMPRESSION_TAR_GZIP
     else:
         LOGGER.warning(
-            "Unable to determine reingested file format,"
-            " defaulting recompression algorithm to bzip2."
+            "Unable to determine reingested file format %s,"
+            " defaulting recompression algorithm to bzip2.",
+            puid
         )
         return COMPRESSION_7Z_BZIP
 

--- a/storage_service/locations/api/resources.py
+++ b/storage_service/locations/api/resources.py
@@ -486,6 +486,7 @@ class LocationResource(ModelResource):
                     source_path=source_path,
                     destination_path=destination_path,
                     destination_space=destination_space,
+                    package=None,
                 )
                 origin_space.post_move_to_storage_service()
                 destination_space.move_from_storage_service(

--- a/storage_service/locations/models/arkivum.py
+++ b/storage_service/locations/models/arkivum.py
@@ -91,7 +91,7 @@ class Arkivum(models.Model):
         if response.status_code != 204:
             raise StorageException("Unable to delete %s", delete_path)
 
-    def move_to_storage_service(self, src_path, dest_path, dest_space):
+    def move_to_storage_service(self, src_path, dest_path, dest_space, package=None):
         """ Moves src_path to dest_space.staging_path/dest_path. """
         # Get from watched dir
         if self.remote_user and self.remote_name:

--- a/storage_service/locations/models/dataverse.py
+++ b/storage_service/locations/models/dataverse.py
@@ -197,7 +197,7 @@ class Dataverse(URLMixin, models.Model):
         entries = list(properties.keys())
         return {"directories": [], "entries": entries, "properties": properties}
 
-    def move_to_storage_service(self, src_path, dest_path, dest_space):
+    def move_to_storage_service(self, src_path, dest_path, dest_space, package=None):
         """
         Fetch dataset with ID `src_path` to dest_space.staging_path/dest_path.
         """

--- a/storage_service/locations/models/dspace.py
+++ b/storage_service/locations/models/dspace.py
@@ -114,7 +114,7 @@ class DSpace(models.Model):
     def delete_path(self, delete_path):
         raise NotImplementedError(_("DSpace does not implement deletion"))
 
-    def move_to_storage_service(self, src_path, dest_path, dest_space):
+    def move_to_storage_service(self, src_path, dest_path, dest_space, package=None):
         """ Moves src_path to dest_space.staging_path/dest_path. """
         raise NotImplementedError(_("DSpace does not implement fetching packages"))
 

--- a/storage_service/locations/models/dspace_rest.py
+++ b/storage_service/locations/models/dspace_rest.py
@@ -166,7 +166,7 @@ class DSpaceREST(models.Model):
     def delete_path(self, delete_path):
         raise NotImplementedError("DSpace does not implement deletion")
 
-    def move_to_storage_service(self, src_path, dest_path, dest_space):
+    def move_to_storage_service(self, src_path, dest_path, dest_space, package=None):
         raise NotImplementedError("DSpace does not implement fetching packages")
 
     @staticmethod

--- a/storage_service/locations/models/duracloud.py
+++ b/storage_service/locations/models/duracloud.py
@@ -287,7 +287,7 @@ class Duracloud(models.Model):
 
         return True
 
-    def move_to_storage_service(self, src_path, dest_path, dest_space):
+    def move_to_storage_service(self, src_path, dest_path, dest_space, package=None):
         """ Moves src_path to dest_space.staging_path/dest_path. """
         # Convert unicode strings to byte strings
         #  .replace() doesn't handle mixed unicode/str well, and it's easiest to put it all in strs

--- a/storage_service/locations/models/gpg.py
+++ b/storage_service/locations/models/gpg.py
@@ -87,7 +87,7 @@ class GPG(models.Model):
         Location.REPLICATOR,
     ]
 
-    def move_to_storage_service(self, src_path, dst_path, dst_space):
+    def move_to_storage_service(self, src_path, dst_path, dst_space, package=None):
         """Moves package at GPG space (at path ``src_path``) to SS at path
         ``dst_path`` and decrypts it there.
         """

--- a/storage_service/locations/models/local_filesystem.py
+++ b/storage_service/locations/models/local_filesystem.py
@@ -36,7 +36,7 @@ class LocalFilesystem(models.Model):
         Location.REPLICATOR,
     ]
 
-    def move_to_storage_service(self, src_path, dest_path, dest_space):
+    def move_to_storage_service(self, src_path, dest_path, dest_space, package=None):
         """ Moves src_path to dest_space.staging_path/dest_path. """
         # Archivematica expects the file to still be on disk even after stored
         self.space.create_local_directory(dest_path)

--- a/storage_service/locations/models/lockssomatic.py
+++ b/storage_service/locations/models/lockssomatic.py
@@ -100,7 +100,7 @@ class Lockssomatic(models.Model):
         LOGGER.warning("Lockssomatic does not support browsing")
         return {"directories": [], "entries": []}
 
-    def move_to_storage_service(self, source_path, destination_path, dest_space):
+    def move_to_storage_service(self, source_path, destination_path, dest_space, package=None):
         """ Moves source_path to dest_space.staging_path/destination_path. """
         # Check if in SS internal, if not then fetch from LOM
         raise NotImplementedError("LOCKSS-o-matic has not implemented retrieval.")

--- a/storage_service/locations/models/nfs.py
+++ b/storage_service/locations/models/nfs.py
@@ -59,7 +59,7 @@ class NFS(models.Model):
         Location.BACKLOG,
     ]
 
-    def move_to_storage_service(self, src_path, dest_path, dest_space):
+    def move_to_storage_service(self, src_path, dest_path, dest_space, package=None):
         """ Moves src_path to dest_space.staging_path/dest_path. """
         self.space.create_local_directory(dest_path)
         return self.space.move_rsync(src_path, dest_path)

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -2302,14 +2302,15 @@ class Package(models.Model):
                 compression_algorithm, __, archive_tool = _get_compression_details_from_premis_events(
                     premis_events, self.uuid
                 )
+                compression_options = {
+                    "bzip2": utils.COMPRESSION_7Z_BZIP,
+                    "lzma": utils.COMPRESSION_7Z_LZMA,
+                    "pbzip2": utils.COMPRESSION_TAR_BZIP2,
+                    "gzip": utils.COMPRESSION_TAR_GZIP,
+                    "copy": utils.COMPRESSION_7Z_COPY,
+                }
                 try:
-                    compression = {
-                        "bzip2": utils.COMPRESSION_7Z_BZIP,
-                        "lzma": utils.COMPRESSION_7Z_LZMA,
-                        "pbzip2": utils.COMPRESSION_TAR_BZIP2,
-                        "tar.gzip": utils.COMPRESSION_TAR_GZIP,
-                        "copy": utils.COMPRESSION_7Z_COPY,
-                    }[compression_algorithm]
+                    compression = compression_options[compression_algorithm]
                     LOGGER.info(
                         'Extracted compression "{}" from AM-passed'
                         " PREMIS events".format(compression)
@@ -2320,7 +2321,7 @@ class Package(models.Model):
                         ' "{}"; does not match any of the following recognized'
                         " options: {}".format(
                             compression_algorithm,
-                            ", ".join(utils.COMPRESSION_ALGORITHMS),
+                            ", ".join(compression_options)
                         )
                     )
                     LOGGER.error(msg)

--- a/storage_service/locations/models/package.py
+++ b/storage_service/locations/models/package.py
@@ -301,6 +301,7 @@ class Package(models.Model):
             ),
             destination_path=self.current_path,
             destination_space=ss_internal.space,
+            package=self,
         )
 
         relative_path = int_path.replace(ss_internal.space.path, "", 1).lstrip("/")
@@ -433,6 +434,7 @@ class Package(models.Model):
                 source_path=source_path,
                 destination_path=destination_path,
                 destination_space=destination_space,
+                package=None,
             )
 
             origin_space.post_move_to_storage_service()
@@ -490,6 +492,7 @@ class Package(models.Model):
             source_path=source_path,
             destination_path=destination_path,
             destination_space=destination_space,
+            package=self,
         )
         origin_space.post_move_to_storage_service()
 
@@ -513,6 +516,7 @@ class Package(models.Model):
             source_path=source_path,
             destination_path=destination_path,
             destination_space=destination_space,
+            package=self,
         )
         origin_space.post_move_to_storage_service()
 
@@ -587,6 +591,7 @@ class Package(models.Model):
             ),
             destination_path=replica_package.current_path,
             destination_space=dest_space,
+            package=self,
         )
         replica_package.status = Package.STAGING
         replica_package.save()
@@ -908,6 +913,7 @@ class Package(models.Model):
                 ),
                 destination_path=self.current_path,  # This should include Location.path
                 destination_space=v.dest_space,
+                package=self,
             )
             # We have to manually construct the AIP's current path here;
             # ``self.get_local_path()`` won't work.
@@ -963,6 +969,7 @@ class Package(models.Model):
                     v.pointer_file_src,
                     self.pointer_file_path,
                     self.pointer_file_location.space,
+                    package=self,
                 )
                 self.pointer_file_location.space.move_from_storage_service(
                     self.pointer_file_path, v.pointer_file_dst, package=None
@@ -1755,6 +1762,7 @@ class Package(models.Model):
             ),
             destination_path=self.current_path,  # This should include Location.path
             destination_space=dest_space,
+            package=self,
         )
 
         try:
@@ -2101,6 +2109,7 @@ class Package(models.Model):
                 source_path=os.path.join(current_location.relative_path, path),
                 destination_path=path,
                 destination_space=currently_processing.space,
+                package=self,
             )
             currently_processing.space.move_from_storage_service(
                 source_path=path,
@@ -2255,7 +2264,7 @@ class Package(models.Model):
             )
             if os.path.isfile(reingest_pointer_src_full_path):
                 origin_space.move_to_storage_service(
-                    reingest_pointer_src, reingest_pointer_name, internal_space
+                    reingest_pointer_src, reingest_pointer_name, internal_space, package=None
                 )
                 internal_space.move_from_storage_service(
                     reingest_pointer_name, reingest_pointer_dst, package=None
@@ -2422,6 +2431,7 @@ class Package(models.Model):
             source_path=os.path.join(origin_location.relative_path, origin_path),
             destination_path=reingest_path,  # This should include Location.path
             destination_space=internal_space,
+            package=self,
         )
         internal_space.move_from_storage_service(
             source_path=reingest_path,  # This should include Location.path
@@ -2569,6 +2579,7 @@ class Package(models.Model):
             source_path=updated_aip_src_path,
             destination_path=dest_path,  # This should include Location.path
             destination_space=reingest_space,
+            package=self,
         )
         storage_effects = reingest_space.move_from_storage_service(
             source_path=dest_path,  # This should include Location.path

--- a/storage_service/locations/models/s3.py
+++ b/storage_service/locations/models/s3.py
@@ -191,7 +191,7 @@ class S3(S3SpaceModelMixin):
         for objectSummary in objects:
             objectSummary.delete()
 
-    def move_to_storage_service(self, src_path, dest_path, dest_space):
+    def move_to_storage_service(self, src_path, dest_path, dest_space, package=None):
         self._ensure_bucket_exists()
         bucket = self.s3_resource.Bucket(self.bucket_name)
 

--- a/storage_service/locations/models/space.py
+++ b/storage_service/locations/models/space.py
@@ -79,7 +79,7 @@ def validate_space_path(path):
 #     def delete_path(self, delete_path):
 #         pass
 #
-#     def move_to_storage_service(self, src_path, dest_path, dest_space):
+#     def move_to_storage_service(self, src_path, dest_path, dest_space, package=None):
 #         """ Moves src_path to dest_space.staging_path/dest_path. """
 #         pass
 #

--- a/storage_service/locations/models/swift.py
+++ b/storage_service/locations/models/swift.py
@@ -183,7 +183,7 @@ class Swift(models.Model):
                 logging.warning(message)
                 raise StorageException(message)
 
-    def move_to_storage_service(self, src_path, dest_path, dest_space):
+    def move_to_storage_service(self, src_path, dest_path, dest_space, package=None):
         """ Moves src_path to dest_space.staging_path/dest_path. """
         try:
             self._download_file(src_path, dest_path)

--- a/storage_service/locations/models/wellcome.py
+++ b/storage_service/locations/models/wellcome.py
@@ -86,7 +86,9 @@ class WellcomeStorageService(S3SpaceModelMixin):
             src_path, dest_path, dest_space)
 
         space_id, source = src_path.lstrip('/').split('/')
-        name, source_id = source.split('-', 1)
+        filename = source
+        filename, ext = source.split('.', 1)
+        name, source_id = filename.split('-', 1)
         version = "v1"
 
         bag = self.wellcome_client.get_bag(space_id, source_id, version=version)
@@ -135,8 +137,11 @@ class WellcomeStorageService(S3SpaceModelMixin):
             space_id = location.relative_path.strip(os.path.sep)
 
             # Store name of package so it can be used on reingest
-            package.current_path = os.path.basename(package.current_path).split('.', 1)[0]
+            LOGGER.debug('Path was %s', package.current_path)
+            package.current_path = os.path.basename(package.current_path)
+            package.status = Package.STAGING
             package.save()
+            LOGGER.debug('Path is now %s', package.current_path)
 
             LOGGER.info('Callback will be to %s', callback_url)
             location = wellcome.create_s3_ingest(

--- a/storage_service/locations/models/wellcome.py
+++ b/storage_service/locations/models/wellcome.py
@@ -55,7 +55,7 @@ def handle_ingest(ingest, package):
             LOGGER.info('{type}: {description}'.format(**event))
 
     else:
-        LOGGER.info("Package status: %s", status)
+        LOGGER.info("Unrecognised package status: %s", status)
 
 
 class WellcomeStorageService(S3SpaceModelMixin):
@@ -181,7 +181,7 @@ class WellcomeStorageService(S3SpaceModelMixin):
             space_id = location.relative_path.strip(os.path.sep)
 
             # For reingests, the package status will still be 'uploaded'
-            # We want to use this to detect when upload is complete,
+            # We use the status to detect when upload is complete,
             # so it is explicitly reset here.
             package.status = Package.STAGING
             package.save()

--- a/storage_service/locations/models/wellcome.py
+++ b/storage_service/locations/models/wellcome.py
@@ -1,5 +1,6 @@
 import logging
 
+import errno
 import os
 import boto3
 import requests
@@ -134,10 +135,14 @@ class WellcomeStorageService(S3SpaceModelMixin):
             bucket.download_file(objectSummary.key, dest_file)
 
         # Ensure the target directory exists
+        dest_dir = os.path.dirname(dest_path)
         try:
-            os.makedirs(os.path.dirname(dest_path))
-        except os.error:
-            pass
+            os.makedirs(dest_dir)
+        except OSError as exc:
+            if exc.errno == errno.EEXIST and os.path.isdir(dest_dir):
+                pass
+            else:
+                raise
 
         # Now compress the temporary dir contents, writing to the destination path
         # Archivematica gave us

--- a/storage_service/locations/models/wellcome.py
+++ b/storage_service/locations/models/wellcome.py
@@ -89,7 +89,7 @@ class WellcomeStorageService(S3SpaceModelMixin):
     def delete_path(self, delete_path):
         LOGGER.debug('Deleting %s from Wellcome storage', delete_path)
 
-    def move_to_storage_service(self, src_path, dest_path, dest_space):
+    def move_to_storage_service(self, src_path, dest_path, dest_space, package=None):
         """ Moves src_path to dest_space.staging_path/dest_path. """
         LOGGER.debug('Fetching %s on Wellcome storage to %s (space %s)',
             src_path, dest_path, dest_space)
@@ -98,10 +98,14 @@ class WellcomeStorageService(S3SpaceModelMixin):
         filename = source
         filename, ext = source.split('.', 1)
         name, source_id = filename.split('-', 1)
-        version = "v1"
 
-        bag = self.wellcome_client.get_bag(space_id, source_id, version=version)
+        bag_kwargs = {}
+        if package and 'bag_version' in package.misc_attributes:
+            bag_kwargs['version'] = package.misc_attributes['bag_version']
+
+        bag = self.wellcome_client.get_bag(space_id, source_id, **bag_kwargs)
         loc = bag['location']
+        version = bag['version']
         LOGGER.debug("Fetching files from s3://%s/%s", loc['bucket'], loc['path'])
         bucket = self.s3_resource.Bucket(loc['bucket'])
 

--- a/storage_service/locations/models/wellcome.py
+++ b/storage_service/locations/models/wellcome.py
@@ -51,6 +51,9 @@ def handle_ingest(ingest, package):
         for event in ingest['events']:
             LOGGER.info('{type}: {description}'.format(**event))
 
+    else:
+        LOGGER.info("Package status: %s", status)
+
 
 class WellcomeStorageService(S3SpaceModelMixin):
     space = models.OneToOneField('Space', to_field='uuid')

--- a/storage_service/locations/models/wellcome.py
+++ b/storage_service/locations/models/wellcome.py
@@ -185,12 +185,12 @@ class WellcomeStorageService(S3SpaceModelMixin):
             )
             LOGGER.info('Ingest_location: %s', location)
 
-            print('Package status %s' % package.status)
+            LOGGER.debug('Package status %s', package.status)
             while package.status == Package.STAGING:
                 # Wait for callback to have been called
                 for i in range(6):
                     package.refresh_from_db()
-                    print('Package status %s' % package.status)
+                    LOGGER.debug('Package status %s', package.status)
                     time.sleep(10)
                     if package.status != Package.STAGING:
                         break

--- a/storage_service/locations/models/wellcome.py
+++ b/storage_service/locations/models/wellcome.py
@@ -116,7 +116,10 @@ class WellcomeStorageService(S3SpaceModelMixin):
         s3_prefix = '%s/%s' % (loc['path'].lstrip('/'), bag['version'])
         objects = bucket.objects.filter(Prefix=s3_prefix)
         for objectSummary in objects:
-            dest_file = objectSummary.key.replace(s3_prefix, tmp_aip_dir, 1)
+            dest_file = os.path.join(
+                tmp_aip_dir,
+                os.path.relpath(objectSummary.key, s3_prefix)
+            )
             self.space.create_local_directory(dest_file)
 
             LOGGER.debug("Downloading %s", objectSummary.key)

--- a/storage_service/locations/models/wellcome.py
+++ b/storage_service/locations/models/wellcome.py
@@ -32,12 +32,18 @@ def handle_ingest(ingest, package):
     """
     status = ingest['status']['id']
     if status == 'succeeded':
-        external_id = ingest['bag']['info']['externalIdentifier']
+        bag_info = ingest['bag']['info']
+        external_id = bag_info['externalIdentifier']
+        bag_version = bag_info['version']
         package.status = Package.UPLOADED
+        package.current_path = os.path.basename(package.current_path)
+        LOGGER.debug('Saving path as %s', package.current_path)
         package.misc_attributes['ingest_id'] = ingest['id']
+        package.misc_attributes['bag_version'] = bag_version
         package.save()
         LOGGER.info('Ingest ID: %s', ingest['id'])
         LOGGER.info('External ID: %s', external_id)
+        LOGGER.info('Bag version: %s', bag_version)
     elif status =='failed':
         LOGGER.error('Ingest failed')
         package.status = Package.FAIL
@@ -150,11 +156,9 @@ class WellcomeStorageService(S3SpaceModelMixin):
             space_id = location.relative_path.strip(os.path.sep)
 
             # Store name of package so it can be used on reingest
-            LOGGER.debug('Path was %s', package.current_path)
-            package.current_path = os.path.basename(package.current_path)
+            LOGGER.debug('Path: %s', package.current_path)
             package.status = Package.STAGING
             package.save()
-            LOGGER.debug('Path is now %s', package.current_path)
 
             LOGGER.info('Callback will be to %s', callback_url)
             location = wellcome.create_s3_ingest(
@@ -167,6 +171,7 @@ class WellcomeStorageService(S3SpaceModelMixin):
             )
             LOGGER.info('Ingest_location: %s', location)
 
+            print('Package status %s' % package.status)
             while package.status == Package.STAGING:
                 # Wait for callback to have been called
                 for i in range(6):

--- a/storage_service/locations/models/wellcome.py
+++ b/storage_service/locations/models/wellcome.py
@@ -33,7 +33,8 @@ def handle_ingest(ingest, package):
     status = ingest['status']['id']
     if status == 'succeeded':
         package.status = Package.UPLOADED
-        # Package path format: NAME-uuid.tar.gz
+        # Strip the directory context from the package path so it is
+        # in the format NAME-uuid.tar.gz
         package.current_path = os.path.basename(package.current_path)
         bag_info = ingest['bag']['info']
         package.misc_attributes['bag_id'] = bag_info['externalIdentifier']
@@ -102,12 +103,15 @@ class WellcomeStorageService(S3SpaceModelMixin):
         name, source_id = filename.split('-', 1)
 
         # Request a specific bag version if the package has one
-        bag_kwargs = {}
+        bag_kwargs = {
+            'space_id': space_id,
+            'source_id': source_id,
+        }
         if package and 'bag_version' in package.misc_attributes:
             bag_kwargs['version'] = package.misc_attributes['bag_version']
 
         # Look up the bag details by UUID
-        bag = self.wellcome_client.get_bag(space_id, source_id, **bag_kwargs)
+        bag = self.wellcome_client.get_bag(**bag_kwargs)
         loc = bag['location']
         LOGGER.debug("Fetching files from s3://%s/%s", loc['bucket'], loc['path'])
         bucket = self.s3_resource.Bucket(loc['bucket'])
@@ -176,6 +180,8 @@ class WellcomeStorageService(S3SpaceModelMixin):
             package.status = Package.STAGING
             package.save()
 
+            # Either create or update a bag on the storage service
+            # https://github.com/wellcometrust/platform/tree/master/docs/rfcs/002-archival_storage#updating-an-existing-bag
             is_reingest = 'bag_id' in package.misc_attributes
             LOGGER.info('Callback will be to %s', callback_url)
             location = wellcome.create_s3_ingest(

--- a/storage_service/locations/models/wellcome.py
+++ b/storage_service/locations/models/wellcome.py
@@ -32,9 +32,8 @@ def handle_ingest(ingest, package):
         external_id = ingest['bag']['info']['externalIdentifier']
         package.status = Package.UPLOADED
         package.misc_attributes['ingest_id'] = ingest['id']
-        package.current_path = external_id
         package.save()
-        LOGGER.info('Ingest ID: %s', external_id)
+        LOGGER.info('Ingest ID: %s', ingest['id'])
         LOGGER.info('External ID: %s', external_id)
     elif status =='failed':
         LOGGER.error('Ingest failed')
@@ -86,16 +85,18 @@ class WellcomeStorageService(S3SpaceModelMixin):
         LOGGER.debug('Fetching %s on Wellcome storage to %s (space %s)',
             src_path, dest_path, dest_space)
 
-        space_id, source_id = src_path.lstrip('/').split('/')
+        space_id, source = src_path.lstrip('/').split('/')
+        name, source_id = source.split('-', 1)
+        version = "v1"
 
-        bag = self.wellcome_client.get_bag(space_id, source_id)
+        bag = self.wellcome_client.get_bag(space_id, source_id, version=version)
         loc = bag['location']
         LOGGER.debug("Fetching files from s3://%s/%s", loc['bucket'], loc['path'])
         bucket = self.s3_resource.Bucket(loc['bucket'])
 
         # The bag is stored unzipped (i.e. as a directory tree).
         # Download all objects in the source directory
-        s3_prefix = loc['path'].lstrip('/')
+        s3_prefix = '%s/%s' % (loc['path'].lstrip('/'), version)
         objects = bucket.objects.filter(Prefix=s3_prefix)
         for objectSummary in objects:
             dest_file = objectSummary.key.replace(s3_prefix, dest_path, 1)
@@ -132,6 +133,10 @@ class WellcomeStorageService(S3SpaceModelMixin):
             # Use the relative_path as the storage service space ID
             location = package.current_location
             space_id = location.relative_path.strip(os.path.sep)
+
+            # Store name of package so it can be used on reingest
+            package.current_path = os.path.basename(package.current_path).split('.', 1)[0]
+            package.save()
 
             LOGGER.info('Callback will be to %s', callback_url)
             location = wellcome.create_s3_ingest(

--- a/storage_service/locations/models/wellcome.py
+++ b/storage_service/locations/models/wellcome.py
@@ -6,6 +6,7 @@ import boto3
 import requests
 import shutil
 import subprocess
+import tarfile
 import tempfile
 import time
 from django.db import models
@@ -146,8 +147,8 @@ class WellcomeStorageService(S3SpaceModelMixin):
 
         # Now compress the temporary dir contents, writing to the destination path
         # Archivematica gave us
-        cmd = ["/bin/tar", "cz", "-C", tmpdir, "-f", dest_path, filename]
-        subprocess.call(cmd)
+        with tarfile.open(dest_path, "w:gz") as tarball:
+            tarball.add(tmp_aip_dir, arcname=filename)
 
         shutil.rmtree(tmpdir)
 

--- a/storage_service/locations/tests/test_wellcome.py
+++ b/storage_service/locations/tests/test_wellcome.py
@@ -160,7 +160,7 @@ class TestWellcomeMoveToStorageService(TestCase):
     @mock.patch('locations.models.wellcome.StorageServiceClient')
     def test_copies_files_from_ia_provider(self, mock_wellcome_client_class):
         self._s3.create_bucket(Bucket='ia-bucket')
-        self._s3.upload_fileobj(StringIO("file contents"), 'ia-bucket', 'bucket-subdir/bag-id/subdir/file1')
+        self._s3.upload_fileobj(StringIO("file contents"), 'ia-bucket', 'bucket-subdir/bag-id/v1/subdir/file1')
 
         mock_wellcome = mock_wellcome_client_class.return_value
         mock_wellcome.get_bag.return_value = {
@@ -174,13 +174,13 @@ class TestWellcomeMoveToStorageService(TestCase):
         }
 
         self.wellcome_object.move_to_storage_service(
-            '/name-of-space/bag-id',
-            os.path.join(self.tmp_dir, 'bag-id'),
+            '/name-of-space/name-bag-id',
+            os.path.join(self.tmp_dir, 'name-bag-id'),
             'space-uuid'
         )
 
-        mock_wellcome.get_bag.assert_called_with('name-of-space', 'bag-id', )
-        assert os.path.exists(os.path.join(self.tmp_dir, 'bag-id/subdir/file1'))
+        mock_wellcome.get_bag.assert_called_with('name-of-space', 'bag-id', version='v1')
+        assert os.path.exists(os.path.join(self.tmp_dir, 'name-bag-id/subdir/file1'))
 
     @mock_s3
     @mock.patch('locations.models.wellcome.StorageServiceClient')

--- a/storage_service/locations/tests/test_wellcome.py
+++ b/storage_service/locations/tests/test_wellcome.py
@@ -79,7 +79,7 @@ class TestWellcomeMoveFromStorageService(TestCase):
     @mock.patch('locations.models.wellcome.StorageServiceClient')
     def test_updates_bag_if_reingest(self, mock_wellcome_client_class, mock_sleep):
         package = self.get_package()
-        package.misc_attributes={'ingest_id': 'my-ingest-id'}
+        package.misc_attributes['bag_id'] = package.uuid
         package.save()
         self.wellcome_object.move_from_storage_service(
             os.path.join(FIXTURES_DIR, 'small_compressed_bag.zip'),
@@ -151,7 +151,7 @@ class TestWellcomeMoveFromStorageService(TestCase):
         package.refresh_from_db()
         assert package.status == models.Package.UPLOADED
         assert package.current_path == 'bag-6465da4a-ea88-4300-ac56-9641125f1276.zip'
-        assert package.misc_attributes['ingest_id'] == 'ingest-id'
+        assert package.misc_attributes['bag_id'] == 'external-id'
         assert package.misc_attributes['bag_version'] == 'v3'
 
     @mock.patch('time.sleep')

--- a/storage_service/locations/tests/test_wellcome.py
+++ b/storage_service/locations/tests/test_wellcome.py
@@ -109,6 +109,7 @@ class TestWellcomeMoveFromStorageService(TestCase):
             'bag': {
                 'info': {
                     'externalIdentifier': 'external-id',
+                    'version': 'v3',
                 }
             },
         }
@@ -123,6 +124,7 @@ class TestWellcomeMoveFromStorageService(TestCase):
         assert package.status == models.Package.UPLOADED
         assert package.current_path == 'bag-6465da4a-ea88-4300-ac56-9641125f1276.zip'
         assert package.misc_attributes['ingest_id'] == 'ingest-id'
+        assert package.misc_attributes['bag_version'] == 'v3'
 
     @mock.patch('time.sleep')
     @mock.patch('locations.models.wellcome.StorageServiceClient')

--- a/storage_service/locations/tests/test_wellcome.py
+++ b/storage_service/locations/tests/test_wellcome.py
@@ -77,6 +77,34 @@ class TestWellcomeMoveFromStorageService(TestCase):
 
     @mock.patch('time.sleep')
     @mock.patch('locations.models.wellcome.StorageServiceClient')
+    def test_updates_bag_if_reingest(self, mock_wellcome_client_class, mock_sleep):
+        package = self.get_package()
+        package.misc_attributes={'ingest_id': 'my-ingest-id'}
+        package.save()
+        self.wellcome_object.move_from_storage_service(
+            os.path.join(FIXTURES_DIR, 'small_compressed_bag.zip'),
+            '/born-digital/bag.zip',
+            package=package
+        )
+
+        mock_wellcome_client_class.assert_called_with(
+            api_url=self.wellcome_object.api_root_url,
+            token_url=self.wellcome_object.token_url,
+            client_id=self.wellcome_object.app_client_id,
+            client_secret=self.wellcome_object.app_client_secret,
+        )
+
+        mock_wellcome_client_class.return_value.create_s3_ingest.assert_called_with(
+            space_id='born-digital',
+            s3_key='born-digital/bag.zip',
+            s3_bucket=self.wellcome_object.s3_bucket,
+            callback_url='https://test.localhost/api/v2/file/6465da4a-ea88-4300-ac56-9641125f1276/wellcome_callback/?username=username&api_key=api_key',
+            external_identifier=package.uuid,
+            ingest_type='update',
+        )
+
+    @mock.patch('time.sleep')
+    @mock.patch('locations.models.wellcome.StorageServiceClient')
     def test_waits_for_callback(self, mock_wellcome_client_class, mock_sleep):
         package = self.get_package()
         self.wellcome_object.move_from_storage_service(
@@ -159,13 +187,14 @@ class TestWellcomeMoveToStorageService(TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmp_dir)
 
+
     @mock_s3
     @mock.patch('locations.models.wellcome.StorageServiceClient')
     def test_copies_files_from_ia_provider(self, mock_wellcome_client_class):
         package = models.Package.objects.get(uuid="6465da4a-ea88-4300-ac56-9641125f1276")
         package.misc_attributes['bag_version'] = 'v3'
         self._s3.create_bucket(Bucket='ia-bucket')
-        self._s3.upload_fileobj(StringIO("file contents"), 'ia-bucket', 'bucket-subdir/bag-id/v1/subdir/file1')
+        self._s3.upload_fileobj(StringIO("file contents"), 'ia-bucket', 'bucket-subdir/bag-id/v3/subdir/file1')
 
         mock_wellcome = mock_wellcome_client_class.return_value
         mock_wellcome.get_bag.return_value = {
@@ -176,7 +205,7 @@ class TestWellcomeMoveToStorageService(TestCase):
                     'id': 'aws-s3-ia',
                 }
             },
-            'version': 'v1',
+            'version': 'v3',
         }
 
         self.wellcome_object.move_to_storage_service(
@@ -188,3 +217,36 @@ class TestWellcomeMoveToStorageService(TestCase):
 
         mock_wellcome.get_bag.assert_called_with('name-of-space', 'bag-id', version='v3')
         assert os.path.exists(os.path.join(self.tmp_dir, 'name-bag-id.tar.gz'))
+
+    @mock_s3
+    @mock.patch('locations.models.wellcome.StorageServiceClient')
+    def test_supports_path_containing_uuid(self, mock_wellcome_client_class):
+        package = models.Package.objects.get(uuid="6465da4a-ea88-4300-ac56-9641125f1276")
+        package.misc_attributes['bag_version'] = 'v3'
+        self._s3.create_bucket(Bucket='ia-bucket')
+        self._s3.upload_fileobj(StringIO("file contents"), 'ia-bucket', 'bucket-subdir/bag-id/v3/subdir/file1')
+
+        mock_wellcome = mock_wellcome_client_class.return_value
+        mock_wellcome.get_bag.return_value = {
+            'location': {
+                'bucket': 'ia-bucket',
+                'path': '/bucket-subdir/bag-id',
+                'provider': {
+                    'id': 'aws-s3-ia',
+                }
+            },
+            'version': 'v3',
+        }
+
+
+        src_path = '/name-of-space/aaaa/bbbb/cccc/dddd/eeee/ffff/gggg/hhhh/name-bag-id.tar.gz'
+        dest_path = os.path.join(self.tmp_dir, 'aaaa/bbbb/cccc/dddd/eeee/ffff/gggg/hhhh/name-bag-id.tar.gz')
+        self.wellcome_object.move_to_storage_service(
+            src_path,
+            dest_path,
+            'space-uuid',
+            package=package,
+        )
+
+        mock_wellcome.get_bag.assert_called_with('name-of-space', 'bag-id', version='v3')
+        assert os.path.exists(dest_path)

--- a/storage_service/locations/tests/test_wellcome.py
+++ b/storage_service/locations/tests/test_wellcome.py
@@ -215,7 +215,7 @@ class TestWellcomeMoveToStorageService(TestCase):
             package=package,
         )
 
-        mock_wellcome.get_bag.assert_called_with('name-of-space', 'bag-id', version='v3')
+        mock_wellcome.get_bag.assert_called_with(space_id='name-of-space', source_id='bag-id', version='v3')
         assert os.path.exists(os.path.join(self.tmp_dir, 'name-bag-id.tar.gz'))
 
     @mock_s3
@@ -248,5 +248,5 @@ class TestWellcomeMoveToStorageService(TestCase):
             package=package,
         )
 
-        mock_wellcome.get_bag.assert_called_with('name-of-space', 'bag-id', version='v3')
+        mock_wellcome.get_bag.assert_called_with(space_id='name-of-space', source_id='bag-id', version='v3')
         assert os.path.exists(dest_path)

--- a/storage_service/locations/tests/test_wellcome.py
+++ b/storage_service/locations/tests/test_wellcome.py
@@ -90,6 +90,7 @@ class TestWellcomeMoveFromStorageService(TestCase):
     @mock.patch('locations.models.wellcome.StorageServiceClient')
     def test_tries_fetching_ingest_if_no_callback(self, mock_wellcome_client_class, mock_sleep):
         package = models.Package.objects.get(uuid="6465da4a-ea88-4300-ac56-9641125f1276")
+        package.current_path = "locations/fixtures/bag-6465da4a-ea88-4300-ac56-9641125f1276.zip"
         package.status = models.Package.STAGING
         package.save()
 
@@ -119,7 +120,7 @@ class TestWellcomeMoveFromStorageService(TestCase):
 
         package.refresh_from_db()
         assert package.status == models.Package.UPLOADED
-        assert package.current_path == 'external-id'
+        assert package.current_path == 'bag-6465da4a-ea88-4300-ac56-9641125f1276'
         assert package.misc_attributes['ingest_id'] == 'ingest-id'
 
     @mock.patch('time.sleep')

--- a/storage_service/locations/tests/test_wellcome.py
+++ b/storage_service/locations/tests/test_wellcome.py
@@ -181,3 +181,27 @@ class TestWellcomeMoveToStorageService(TestCase):
 
         mock_wellcome.get_bag.assert_called_with('name-of-space', 'bag-id', )
         assert os.path.exists(os.path.join(self.tmp_dir, 'bag-id/subdir/file1'))
+
+    @mock_s3
+    @mock.patch('locations.models.wellcome.StorageServiceClient')
+    def test_raises_error_if_no_ia_provider(self, mock_wellcome_client_class):
+
+        mock_wellcome = mock_wellcome_client_class.return_value
+        mock_wellcome.get_bag.return_value = {
+            'locations': [
+                {
+                    'bucket': 'ia-bucket',
+                    'path': '/bucket-subdir/bag-id',
+                    'provider': {
+                        'id': 'some-other-provider',
+                    }
+                }
+            ]
+        }
+
+        with pytest.raises(models.StorageException):
+            self.wellcome_object.move_to_storage_service(
+                '/name-of-space/bag-id',
+                os.path.join(self.tmp_dir, 'bag-id'),
+                'space-uuid'
+            )

--- a/storage_service/locations/tests/test_wellcome.py
+++ b/storage_service/locations/tests/test_wellcome.py
@@ -162,6 +162,8 @@ class TestWellcomeMoveToStorageService(TestCase):
     @mock_s3
     @mock.patch('locations.models.wellcome.StorageServiceClient')
     def test_copies_files_from_ia_provider(self, mock_wellcome_client_class):
+        package = models.Package.objects.get(uuid="6465da4a-ea88-4300-ac56-9641125f1276")
+        package.misc_attributes['bag_version'] = 'v3'
         self._s3.create_bucket(Bucket='ia-bucket')
         self._s3.upload_fileobj(StringIO("file contents"), 'ia-bucket', 'bucket-subdir/bag-id/v1/subdir/file1')
 
@@ -173,14 +175,16 @@ class TestWellcomeMoveToStorageService(TestCase):
                 'provider': {
                     'id': 'aws-s3-ia',
                 }
-            }
+            },
+            'version': 'v1',
         }
 
         self.wellcome_object.move_to_storage_service(
             '/name-of-space/name-bag-id.tar.gz',
             os.path.join(self.tmp_dir, 'name-bag-id.tar.gz'),
-            'space-uuid'
+            'space-uuid',
+            package=package,
         )
 
-        mock_wellcome.get_bag.assert_called_with('name-of-space', 'bag-id', version='v1')
+        mock_wellcome.get_bag.assert_called_with('name-of-space', 'bag-id', version='v3')
         assert os.path.exists(os.path.join(self.tmp_dir, 'name-bag-id.tar.gz'))


### PR DESCRIPTION
Fixes https://github.com/wellcometrust/platform/issues/2836

This gets the Wellcome storage plugin working with the Archivematica reingest feature, so packages can be fetched from storage, re-run through Archivematica and re-uploaded to the storage service as a new version.

A couple of notes about this:
* Changes the `current_path` and `misc_attributes` fields on the AIP `Package` object in order to store correctly for reingest. So any already-ingested packages will not work with reingest. New ingests will need to be created.
* Adds a `package` parameter to `move_to_storage_service` so that we can access package fields when retrieving the AIP.