### PR TITLE
Use download bag method

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -22,7 +22,7 @@ python-swiftclient==3.3.0
 requests==2.21.0
 requests-oauthlib==1.2.0
 sword2==0.2.1
-wellcome-storage-service==1.2.1
+wellcome-storage-service==1.3.0
 whitenoise==3.3.0
 agentarchives==0.4.0
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -76,6 +76,6 @@ six==1.12.0               # via cryptography, debtcollector, django-extensions, 
 stevedore==1.30.1         # via keystoneauth1, oslo.config, python-keystoneclient
 sword2==0.2.1
 urllib3==1.24.3           # via botocore, requests
-wellcome-storage-service==1.2.1
+wellcome-storage-service==1.3.0
 whitenoise==3.3.0
 wrapt==1.11.1             # via debtcollector, positional

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -86,6 +86,6 @@ stevedore==1.30.1
 sword2==0.2.1
 transifex-client==0.12.2
 urllib3==1.24.3
-wellcome-storage-service==1.2.1
+wellcome-storage-service==1.3.0
 whitenoise==3.3.0
 wrapt==1.11.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -78,6 +78,6 @@ six==1.12.0
 stevedore==1.30.1
 sword2==0.2.1
 urllib3==1.24.3
-wellcome-storage-service==1.2.1
+wellcome-storage-service==1.3.0
 whitenoise==3.3.0
 wrapt==1.11.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -134,7 +134,7 @@ vcrpy==2.0.1
 virtualenv==16.6.0        # via tox
 wcwidth==0.1.7            # via prompt-toolkit
 websocket-client==0.56.0  # via docker
-wellcome-storage-service==1.2.1
+wellcome-storage-service==1.3.0
 werkzeug==0.15.2          # via moto
 whitenoise==3.3.0
 wrapt==1.11.1

--- a/storage_service/locations/models/wellcome.py
+++ b/storage_service/locations/models/wellcome.py
@@ -13,7 +13,7 @@ from django.db import models
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.utils.six.moves.urllib.parse import urljoin, urlencode
-from wellcome_storage_service import download_bag, StorageServiceClient
+from wellcome_storage_service import download_compressed_bag, StorageServiceClient
 
 from . import StorageException
 from . import Package
@@ -115,11 +115,6 @@ class WellcomeStorageService(S3SpaceModelMixin):
         # Look up the bag details by UUID
         bag = self.wellcome_client.get_bag(**bag_kwargs)
 
-        # Download the bag contents to a temporary space
-        tmpdir = tempfile.mkdtemp()
-        tmp_aip_dir = os.path.join(tmpdir, filename)
-        download_bag(storage_manifest=bag, out_dir=tmp_aip_dir)
-
         # Ensure the target directory exists. This is where the tarball
         # will be created.
         dest_dir = os.path.dirname(dest_path)
@@ -131,13 +126,7 @@ class WellcomeStorageService(S3SpaceModelMixin):
             else:
                 raise
 
-        LOGGER.debug("Compressing %s to %s", tmp_aip_dir, dest_path)
-        # Now compress the temporary dir contents, writing to the destination path
-        # Archivematica gave us
-        with tarfile.open(dest_path, "w:gz") as tarball:
-            tarball.add(tmp_aip_dir, arcname=filename)
-
-        shutil.rmtree(tmpdir)
+        download_compressed_bag(storage_manifest=bag, out_path=dest_path)
 
     def move_from_storage_service(self, src_path, dest_path, package=None):
         """ Moves self.staging_path/src_path to dest_path. """

--- a/storage_service/locations/tests/test_wellcome.py
+++ b/storage_service/locations/tests/test_wellcome.py
@@ -194,19 +194,31 @@ class TestWellcomeMoveToStorageService(TestCase):
         package = models.Package.objects.get(uuid="6465da4a-ea88-4300-ac56-9641125f1276")
         package.misc_attributes['bag_version'] = 'v3'
         self._s3.create_bucket(Bucket='ia-bucket')
-        self._s3.upload_fileobj(StringIO("file contents"), 'ia-bucket', 'bucket-subdir/bag-id/v3/subdir/file1')
+        self._s3.upload_fileobj(StringIO("file contents"), 'ia-bucket', 'bucket-subdir/bag-id/v3/data/file1')
 
         mock_wellcome = mock_wellcome_client_class.return_value
         mock_wellcome.get_bag.return_value = {
             'location': {
                 'bucket': 'ia-bucket',
-                'path': '/bucket-subdir/bag-id',
+                'path': 'bucket-subdir/bag-id',
                 'provider': {
                     'id': 'aws-s3-ia',
                 }
             },
+            'manifest': {
+                'files': [
+                    {
+                        'name': 'data/file1',
+                        'path': 'v3/data/file1',
+                    }
+                ]
+            },
+            'tagManifest': {
+                'files': []
+            },
             'version': 'v3',
         }
+
 
         self.wellcome_object.move_to_storage_service(
             '/name-of-space/name-bag-id.tar.gz',
@@ -224,16 +236,27 @@ class TestWellcomeMoveToStorageService(TestCase):
         package = models.Package.objects.get(uuid="6465da4a-ea88-4300-ac56-9641125f1276")
         package.misc_attributes['bag_version'] = 'v3'
         self._s3.create_bucket(Bucket='ia-bucket')
-        self._s3.upload_fileobj(StringIO("file contents"), 'ia-bucket', 'bucket-subdir/bag-id/v3/subdir/file1')
+        self._s3.upload_fileobj(StringIO("file contents"), 'ia-bucket', 'bucket-subdir/bag-id/v3/data/file1')
 
         mock_wellcome = mock_wellcome_client_class.return_value
         mock_wellcome.get_bag.return_value = {
             'location': {
                 'bucket': 'ia-bucket',
-                'path': '/bucket-subdir/bag-id',
+                'path': 'bucket-subdir/bag-id',
                 'provider': {
                     'id': 'aws-s3-ia',
-                }
+                },
+            },
+            'manifest': {
+                'files': [
+                    {
+                        'name': 'data/file1',
+                        'path': 'v3/data/file1',
+                    }
+                ]
+            },
+            'tagManifest': {
+                'files': []
             },
             'version': 'v3',
         }

--- a/storage_service/locations/tests/test_wellcome.py
+++ b/storage_service/locations/tests/test_wellcome.py
@@ -210,6 +210,7 @@ class TestWellcomeMoveToStorageService(TestCase):
                     {
                         'name': 'data/file1',
                         'path': 'v3/data/file1',
+                        'size': 13,
                     }
                 ]
             },
@@ -252,6 +253,7 @@ class TestWellcomeMoveToStorageService(TestCase):
                     {
                         'name': 'data/file1',
                         'path': 'v3/data/file1',
+                        'size': 13,
                     }
                 ]
             },


### PR DESCRIPTION
Fixes https://github.com/wellcometrust/platform/issues/3955

Calls the `download_compressed_bag` function in a separate subprocess to prevent the CPU-intensive compression from locking up Archivematica.

Once this is merged and deployed, we can re-evaluate https://github.com/wellcometrust/platform/issues/3954