### PR TITLE
Specify top level dir

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -22,7 +22,7 @@ python-swiftclient==3.3.0
 requests==2.21.0
 requests-oauthlib==1.2.0
 sword2==0.2.1
-wellcome-storage-service==1.4.1
+wellcome-storage-service==1.5.0
 whitenoise==3.3.0
 agentarchives==0.4.0
 git+https://github.com/Brown-University-Library/django-shibboleth-remoteuser.git@67d270c65c201606fb86d548493d4b3fd8cc7a76#egg=django-shibboleth-remoteuser

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -78,6 +78,6 @@ six==1.12.0               # via cryptography, debtcollector, django-extensions, 
 stevedore==1.30.1         # via keystoneauth1, oslo.config, python-keystoneclient
 sword2==0.2.1
 urllib3==1.24.3           # via botocore, requests
-wellcome-storage-service==1.4.1
+wellcome-storage-service==1.5.0
 whitenoise==3.3.0
 wrapt==1.11.1             # via debtcollector, positional

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -88,6 +88,6 @@ stevedore==1.30.1
 sword2==0.2.1
 transifex-client==0.12.2
 urllib3==1.24.3
-wellcome-storage-service==1.4.1
+wellcome-storage-service==1.5.0
 whitenoise==3.3.0
 wrapt==1.11.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -80,6 +80,6 @@ six==1.12.0
 stevedore==1.30.1
 sword2==0.2.1
 urllib3==1.24.3
-wellcome-storage-service==1.4.1
+wellcome-storage-service==1.5.0
 whitenoise==3.3.0
 wrapt==1.11.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -136,7 +136,7 @@ vcrpy==2.0.1
 virtualenv==16.6.0        # via tox
 wcwidth==0.1.7            # via prompt-toolkit
 websocket-client==0.56.0  # via docker
-wellcome-storage-service==1.4.1
+wellcome-storage-service==1.5.0
 werkzeug==0.15.2          # via moto
 whitenoise==3.3.0
 wrapt==1.11.1

--- a/storage_service/common/tests/test_utils.py
+++ b/storage_service/common/tests/test_utils.py
@@ -17,6 +17,9 @@ PROG_VERS_TAR = "tar"
 COMPRESS_ORDER_ONE = "1"
 COMPRESS_ORDER_TWO = "2"
 
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+FILES_DIR = os.path.abspath(os.path.join(THIS_DIR, 'files'))
+
 
 @pytest.mark.parametrize(
     "pronom,algorithm,compression",
@@ -264,13 +267,13 @@ def test_get_format_info(compression, version, extension, program_name, transfor
 
 @pytest.mark.parametrize("name, directories", [
     # An archive created from three nested folders and a single file
-    ("a.tar.gz", ["a", "a/b", "a/b/c"]),
+    ("a.tar.gz", {"a", "a/b", "a/b/c"}),
 
     # An archive that contains a single text file
-    ("hello.txt.tbz", []),
+    ("hello.txt.tbz", set()),
 ])
 def test_list_archive_directories(name, directories):
-    path = os.path.abspath(os.path.join("files", name))
+    path = os.path.join(FILES_DIR, name)
     assert utils.list_archive_directories(path) == directories
 
 
@@ -279,12 +282,12 @@ def test_list_archive_directories(name, directories):
     ("a.tar.gz", "a"),
 ])
 def test_get_base_directory(name, base_directory):
-    path = os.path.abspath(os.path.join("files", name))
+    path = os.path.join(FILES_DIR, name)
     assert utils.get_base_directory(path) == base_directory
 
 
 def test_get_base_directory_when_no_directory():
-    path = os.path.abspath(os.path.join("files", "hello.txt.tbz"))
+    path = os.path.join(FILES_DIR, "hello.txt.tbz")
 
     with pytest.raises(ValueError, match="Could not find base directory"):
         utils.get_base_directory(path)

--- a/storage_service/locations/models/wellcome.py
+++ b/storage_service/locations/models/wellcome.py
@@ -37,8 +37,9 @@ from wellcome_storage_service import download_compressed_bag
 
 bag = json.loads(sys.argv[1])
 dest_path = sys.argv[2]
+top_level_dir=sys.argv[3]
 
-download_compressed_bag(storage_manifest=bag, out_path=dest_path)
+download_compressed_bag(storage_manifest=bag, out_path=dest_path, top_level_dir=top_level_dir)
 '''
 
 def handle_ingest(ingest, package):
@@ -150,7 +151,8 @@ class WellcomeStorageService(S3SpaceModelMixin):
             'python',
             '-c', DOWNLOAD_BAG_SCRIPT,
             json.dumps(bag),
-            dest_path
+            dest_path,
+            filename,
         ], stderr=subprocess.STDOUT)
 
     def move_from_storage_service(self, src_path, dest_path, package=None):

--- a/storage_service/locations/tests/test_wellcome.py
+++ b/storage_service/locations/tests/test_wellcome.py
@@ -239,7 +239,8 @@ class TestWellcomeMoveToStorageService(TestCase):
             '-c',
             mock.ANY,
             mock.ANY,
-            dest_path
+            dest_path,
+            'name-bag-id',
         ], stderr=subprocess.STDOUT)
         assert json.loads(mock_call.call_args[0][0][3]) == mock_wellcome.get_bag.return_value
 


### PR DESCRIPTION
Pass in extra parameter (as introduced in https://github.com/wellcometrust/platform/issues/4071) so that top level dir in downloaded bag is correctly named.

Should fix https://github.com/wellcometrust/platform/issues/4004

I also realised the tests were failing from a previous commit (at least in my local docker container) so have tweaked the directory handling to deal with this a bit more robustly.